### PR TITLE
Fix Prompt's handling

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -1,6 +1,7 @@
 package libsecret
 
 import (
+  "fmt"
   "github.com/godbus/dbus"
   "strings"
 )
@@ -33,6 +34,14 @@ func isPrompt(path dbus.ObjectPath) bool {
 
 // Prompt (IN String window-id);
 func (prompt *Prompt) Prompt() (*dbus.Variant, error) {
+  // Secret Service API specification doesn't specify whether signals are broadcast or unicast so it depends on the specific server implementation
+  // We need to explicitly connect to signal to handle both cases
+  args := fmt.Sprintf("type='signal',path='%s',interface='%s',sender='%s'", prompt.Path(), "org.freedesktop.Secret.Prompt", DBusServiceName)
+  err := prompt.conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, args).Store()
+  if err != nil {
+    return &dbus.Variant{}, err
+  }
+
   // prompts are asynchronous so we connect to the signal
   // and block with a channel until we get a response
   c := make(chan *dbus.Signal, 10)
@@ -41,7 +50,7 @@ func (prompt *Prompt) Prompt() (*dbus.Variant, error) {
   prompt.conn.Signal(c)
   defer prompt.conn.RemoveSignal(c)
 
-  err := prompt.dbus.Call("org.freedesktop.Secret.Prompt.Prompt", 0, "").Store()
+  err = prompt.dbus.Call("org.freedesktop.Secret.Prompt.Prompt", 0, "").Store()
   if err != nil {
     return &dbus.Variant{}, err
   }


### PR DESCRIPTION
Secret Service API [specification](https://specifications.freedesktop.org/secret-service) doesn't specify whether signals are broadcast or unicast so it depends on the specific server implementation.
Because of that it seems we have to explicitly connect to signal to handle both cases, otherwise we might miss the response and hang waiting (hit this with [aws-vault](https://github.com/99designs/aws-vault) that uses this library).

While I found two (most popular?) implementations use unicast signals:
- [kwallet](https://invent.kde.org/frameworks/kwallet/-/blob/master/src/runtime/kwalletd/kwalletfreedesktopprompt.cpp#L100)
- [gnome-keyring](https://gitlab.gnome.org/GNOME/gnome-keyring/-/blob/master/daemon/dbus/gkd-secret-prompt.c#L77)

For example [keepassxc](https://github.com/keepassxreboot/keepassxc/issues/7759) doesn't and just issues broadcast signals, and widely used client library [libsecret](https://gitlab.gnome.org/GNOME/libsecret/-/blob/master/libsecret/secret-prompt.c#L463) also explicitly subscribes to the signals making all other clients work regardless of the transmission type.